### PR TITLE
Forced JSON mode on all models that support it.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -127,7 +127,7 @@ async function getAIResponse(prompt: string): Promise<Array<{
     const response = await openai.chat.completions.create({
       ...queryConfig,
       // return JSON if the model supports it:
-      ...(OPENAI_API_MODEL === "gpt-4-turbo-preview" || OPENAI_API_MODEL === "gpt-4-0125-preview" || OPENAI_API_MODEL === "gpt-4-1106-preview"
+      ...(OPENAI_API_MODEL === "gpt-4-turbo-preview" || OPENAI_API_MODEL === "gpt-3.5-turbo" || OPENAI_API_MODEL === "gpt-4-0125-preview" || OPENAI_API_MODEL === "gpt-4-1106-preview" || OPENAI_API_MODEL === "gpt-3.5-turbo-0125" || OPENAI_API_MODEL === "gpt-3.5-turbo-1106"
         ? { response_format: { type: "json_object" } }
         : {}),
       messages: [

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,7 +127,7 @@ async function getAIResponse(prompt: string): Promise<Array<{
     const response = await openai.chat.completions.create({
       ...queryConfig,
       // return JSON if the model supports it:
-      ...(OPENAI_API_MODEL === "gpt-4-1106-preview"
+      ...(OPENAI_API_MODEL === "gpt-4-turbo-preview" || OPENAI_API_MODEL === "gpt-4-0125-preview" || OPENAI_API_MODEL === "gpt-4-1106-preview"
         ? { response_format: { type: "json_object" } }
         : {}),
       messages: [

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,7 +127,7 @@ async function getAIResponse(prompt: string): Promise<Array<{
     const response = await openai.chat.completions.create({
       ...queryConfig,
       // return JSON if the model supports it:
-      ...(OPENAI_API_MODEL === "gpt-4-turbo-preview" || OPENAI_API_MODEL === "gpt-3.5-turbo" || OPENAI_API_MODEL === "gpt-4-0125-preview" || OPENAI_API_MODEL === "gpt-4-1106-preview" || OPENAI_API_MODEL === "gpt-3.5-turbo-0125" || OPENAI_API_MODEL === "gpt-3.5-turbo-1106"
+      ...(OPENAI_API_MODEL === "gpt-4-turbo-preview" || OPENAI_API_MODEL === "gpt-4-turbo" || OPENAI_API_MODEL === "gpt-3.5-turbo" || OPENAI_API_MODEL === "gpt-4-0125-preview" || OPENAI_API_MODEL === "gpt-4-1106-preview" || OPENAI_API_MODEL === "gpt-3.5-turbo-0125" || OPENAI_API_MODEL === "gpt-3.5-turbo-1106"
         ? { response_format: { type: "json_object" } }
         : {}),
       messages: [


### PR DESCRIPTION
This is a fix for Issue #56, ultimately caused by invalid JSON output being produced by the model, by forcing JSON mode on all supported models.

Was previously only forced on `gpt-4-1106-preview`, but OpenAI supports JSON mode on the latest GPT-3 and GPT-4 turbo models. See https://platform.openai.com/docs/guides/text-generation/json-mode.

Put `gpt-4-turbo-preview`, `gpt-4-turbo`, and `gpt-3.5-turbo` first in the conditional for efficiency. Put `gpt-4-turbo` - a model that does not exist yet - in the conditional to future-proof once GPT-4 Turbo goes out of preview.