### PR TITLE
Added custom prompt support.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: "Glob patterns to exclude files from the diff analysis"
     required: false
     default: ""
+  custom_prompts:
+    description: "Custom commands to augment the agent's prompts with. Each line is an individual command."
+    required: false
+    default: ""
 runs:
   using: "node16"
   main: "dist/index.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,14 +58,15 @@ async function getDiff(
 
 async function analyzeCode(
   parsedDiff: File[],
-  prDetails: PRDetails
+  prDetails: PRDetails,
+  customPrompts: string
 ): Promise<Array<{ body: string; path: string; line: number }>> {
   const comments: Array<{ body: string; path: string; line: number }> = [];
 
   for (const file of parsedDiff) {
     if (file.to === "/dev/null") continue; // Ignore deleted files
     for (const chunk of file.chunks) {
-      const prompt = createPrompt(file, chunk, prDetails);
+      const prompt = createPrompt(file, chunk, prDetails, customPrompts);
       const aiResponse = await getAIResponse(prompt);
       if (aiResponse) {
         const newComments = createComment(file, chunk, aiResponse);
@@ -78,7 +79,7 @@ async function analyzeCode(
   return comments;
 }
 
-function createPrompt(file: File, chunk: Chunk, prDetails: PRDetails): string {
+function createPrompt(file: File, chunk: Chunk, prDetails: PRDetails, customPrompts: string): string {
   return `Your task is to review pull requests. Instructions:
 - Provide the response in following JSON format:  {"reviews": [{"lineNumber":  <line_number>, "reviewComment": "<review comment>"}]}
 - Do not give positive comments or compliments.
@@ -86,6 +87,7 @@ function createPrompt(file: File, chunk: Chunk, prDetails: PRDetails): string {
 - Write the comment in GitHub Markdown format.
 - Use the given description only for the overall context and only comment the code.
 - IMPORTANT: NEVER suggest adding comments to the code.
+${customPrompts}
 
 Review the following code diff in the file "${
     file.to
@@ -232,7 +234,11 @@ async function main() {
     );
   });
 
-  const comments = await analyzeCode(filteredDiff, prDetails);
+  const customPrompts = core.getMultilineInput("custom_prompts")
+      .map(customPrompt => `- ${customPrompt}`)
+      .join("\n")
+
+  const comments = await analyzeCode(filteredDiff, prDetails, customPrompts);
   if (comments.length > 0) {
     await createReviewComment(
       prDetails.owner,


### PR DESCRIPTION
This pull request adds custom command support to the prompt passed to the LLM when asking it to review files.

In a repository's workflow configuration file for AI Code Reviewer, one can use multiline YAML to specify said custom commands in the `custom_prompt` input. For example, see the bottom of →

```yaml
name: Code Review with OpenAI
on:
  pull_request:
    types:
      - opened
      - synchronize
      - ready_for_review
permissions: write-all
jobs:
  code_review:
    if: '! github.event.pull_request.draft'
    runs-on: ubuntu-latest
    steps:
      - name: Checkout repository
        uses: actions/checkout@v3
      - name: Code Review
        uses: lukehollenback/ai-codereviewer@main-luke
        with:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
          OPENAI_API_MODEL: "gpt-4-turbo-preview"
          exclude: "yarn.lock, dist/**, **/*.json, **/*.md, **/*.yaml, **/*.xml"
          custom_prompts: |
            Do not worry about the verbosity of variable names, as long as they are somewhat descriptive.
            Be sure to call out potential null pointer exceptions.
```

Tested over in https://github.com/lukehollenback/ai-codereviewer/pull/4 — see executed checks.