### PR TITLE
Made maximum number of output tokens configurable, and added debug output.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "OpenAI API model."
     required: false
     default: "gpt-4"
+  max_tokens:
+    description: "Maximum number of tokens that can be generated per analysis."
+    required: false
+    default: "700"
   exclude:
     description: "Glob patterns to exclude files from the diff analysis"
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -138,11 +138,9 @@ async function getAIResponse(prompt: string): Promise<Array<{
       ],
     });
 
-    console.log(`Completions Response Object: ${response}`);
-
     const res = response.choices[0].message?.content?.trim() || "{}";
 
-    console.log(`Trimmed Response Message: ${res}`);
+    console.log(`Trimmed Response: ${res}`);
 
     return JSON.parse(res).reviews;
   } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -138,7 +138,12 @@ async function getAIResponse(prompt: string): Promise<Array<{
       ],
     });
 
+    console.log(`Completions Response Object: ${response}`);
+
     const res = response.choices[0].message?.content?.trim() || "{}";
+
+    console.log(`Trimmed Response Message: ${res}`);
+
     return JSON.parse(res).reviews;
   } catch (error) {
     console.error("Error:", error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import minimatch from "minimatch";
 const GITHUB_TOKEN: string = core.getInput("GITHUB_TOKEN");
 const OPENAI_API_KEY: string = core.getInput("OPENAI_API_KEY");
 const OPENAI_API_MODEL: string = core.getInput("OPENAI_API_MODEL");
+const MAX_TOKENS: number = Number(core.getInput("max_tokens"));
 
 const octokit = new Octokit({ auth: GITHUB_TOKEN });
 
@@ -117,7 +118,7 @@ async function getAIResponse(prompt: string): Promise<Array<{
   const queryConfig = {
     model: OPENAI_API_MODEL,
     temperature: 0.2,
-    max_tokens: 700,
+    max_tokens: MAX_TOKENS,
     top_p: 1,
     frequency_penalty: 0,
     presence_penalty: 0,


### PR DESCRIPTION
Just in case https://github.com/freeedcom/ai-codereviewer/pull/57 does not fully get to the bottom of the JSON parsing issue in Issue #56, this pull request adds some extra debug output.

It also makes the maximum number of output tokens configurable. Another suspicion is that the hardcoded 700 limit was just too small for some large pull requests that needed a lot of commentary.